### PR TITLE
Generate Kotlin files importable to Element Android project

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
     "quicktype": "^15.0.260"
   },
   "scripts": {
-    "build": "yarn build:ts && yarn build:kt && yarn build:swift",
+    "build": "yarn build:ts && yarn build:kt && yarn build:swift && yarn build:kt2",
     "build:ts": "scripts/build-typescript.sh",
     "build:kt": "scripts/build-kotlin.sh",
+    "build:kt2": "scripts/build-kotlin2.sh",
     "build:swift": "scripts/build-swift.sh"
   }
 }

--- a/scripts/build-kotlin2.sh
+++ b/scripts/build-kotlin2.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+rm types/kotlin2/*
+
+set -e
+
+for json in schemas/*.json
+do
+  json_basename=$(basename $json);
+  kotlin_path=types/kotlin2/${json_basename%.*}.kt
+  python3 scripts/kotlin_generator.py -s $json > $kotlin_path
+done;

--- a/scripts/kotlin_generator.py
+++ b/scripts/kotlin_generator.py
@@ -22,13 +22,13 @@ def first_letter_up(str):
 @dataclass
 class Enum():
     name: str
-    values: []
+    values: list[object]
         
 @dataclass
 class Member():
     name:str
     type: str
-    enum: []
+    enum: list[str]
     description: str
     required: bool
     def __lt__(self, other):

--- a/scripts/kotlin_generator.py
+++ b/scripts/kotlin_generator.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+import json
+import argparse
+import os
+
+parser = argparse.ArgumentParser(description='Create Kotlin file from Json schema')
+parser.add_argument('-s', '--source', dest='json_schema',
+                   help='Json shema file', required=True)
+
+args = parser.parse_args()
+
+# Capitalize also change the next letter.
+def firstLetterUp(str):
+    return str[0].upper() + str[1:]
+
+class Enum(object):
+    """docstring for Enum"""
+    def __init__(self, name, values):
+        super(Enum, self).__init__()
+        self.name = name
+        self.values = values
+        
+class Member(object):
+    """docstring for Member"""
+    def __init__(self, name, type, enum, description, required):
+        super(Member, self).__init__()
+        self.name = name
+        self.type = type
+        self.enum = enum
+        self.description = description
+        self.required = required
+    def __lt__(self, other):
+        return self.name < other.name
+        
+with open(args.json_schema) as json_file:
+    klass = os.path.basename(args.json_schema).removesuffix(".json")
+    isScreen = klass == "Screen"
+    data = json.load(json_file)
+
+    # Parse
+    members = list()
+    enums = list()
+    name = data['properties']['eventName']['enum'][0]
+    required = data.get('required')
+    for p in data['properties']:
+        if(p == 'eventName'):
+            continue
+        enum = data['properties'][p].get('enum')
+        if(enum):
+            enums.append(Enum(firstLetterUp(p), enum))
+
+        members.append(
+            Member(
+                p,
+                data['properties'][p].get('type'),
+                enum,
+                data['properties'][p].get('description'),
+                p in required or data['properties'][p].get('required')
+                )
+            )
+    members.sort()
+
+    # Print output
+    print("""/*
+ * Copyright (c) 2021 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.analytics.plan
+""")
+
+    if(isScreen):
+        itf = "VectorAnalyticsScreen"
+    else:
+        itf = "VectorAnalyticsEvent"
+
+    print("import im.vector.app.features.analytics.itf.%s" % itf)
+    print("")
+    print("// GENERATED FILE, DO NOT EDIT")
+    print("")
+    print("/**")
+    print(" * %s" % data["description"])
+    print(" */")
+    print("data class %s(" % klass)
+
+    for member in members:
+        if(member.description):
+            print('    /**')
+            print('     * ' + member.description)
+            print('     */')
+        if(member.required):
+            defaultValue = ""
+        else:
+            defaultValue = "? = null"
+        if(member.type == 'string'):
+            if(member.enum):
+                print('    val ' + member.name + ': ' + firstLetterUp(member.name) + defaultValue + ',')
+            else:
+                print('    val ' + member.name + ': String' + defaultValue + ',')                    
+        elif(member.type == 'number'):
+            print('    val ' + member.name + ': Double' + defaultValue + ',')
+        elif(member.type == 'integer'):
+            print('    val ' + member.name + ': Int' + defaultValue + ',')
+        elif(member.type == 'boolean'):
+            print('    val ' + member.name + ': Boolean' + defaultValue + ',')
+        else:
+            raise Exception("Not handled yet: %s" % member.type)
+
+    print(") : %s {" % itf)
+
+    for enum in enums:
+        print("")
+        print("    enum class %s {" % enum.name)
+        enum.values.sort()
+        for value in enum.values:
+            print("        %s," % value)
+        print("    }")
+        
+
+    print("")
+    if(isScreen):
+        print("    override fun getName() = screenName.name")
+    else:
+        print("    override fun getName() = \"%s\"" % name)
+
+    print("")
+    if(not members):
+        print("    override fun getProperties(): Map<String, Any>? = null")
+    else:
+        print("    override fun getProperties(): Map<String, Any>? {")
+        print("        return mutableMapOf<String, Any>().apply {")
+        for member in members:
+            if(member.name == "screenName" and isScreen):
+                continue
+            if member.required:
+                if(member.enum):
+                    print("            put(\"%s\", %s.name)" % (member.name, member.name))
+                else:
+                    print("            put(\"%s\", %s)" % (member.name, member.name))
+            else:
+                if(member.enum):
+                    print("            %s?.let { put(\"%s\", it.name) }" % (member.name, member.name))
+                else:
+                    print("            %s?.let { put(\"%s\", it) }" % (member.name, member.name))
+        print("        }.takeIf { it.isNotEmpty() }")
+        print("    }")
+
+    print("}")

--- a/types/kotlin2/Error.kt
+++ b/types/kotlin2/Error.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.analytics.plan
+
+import im.vector.app.features.analytics.itf.VectorAnalyticsEvent
+
+// GENERATED FILE, DO NOT EDIT
+
+/**
+ * Triggered when an error occurred
+ */
+data class Error(
+    /**
+     * Context - client defined, can be used for debugging
+     */
+    val context: String? = null,
+    val domain: Domain,
+    val name: Name,
+) : VectorAnalyticsEvent {
+
+    enum class Domain {
+        E2EE,
+        VOIP,
+    }
+
+    enum class Name {
+        OlmIndexError,
+        OlmKeysNotSentError,
+        OlmUnspecifiedError,
+        UnknownError,
+        VoipIceFailed,
+        VoipIceTimeout,
+        VoipInviteTimeout,
+        VoipUserHangup,
+        VoipUserMediaFailed,
+    }
+
+    override fun getName() = "Error"
+
+    override fun getProperties(): Map<String, Any>? {
+        return mutableMapOf<String, Any>().apply {
+            context?.let { put("context", it) }
+            put("domain", domain.name)
+            put("name", name.name)
+        }.takeIf { it.isNotEmpty() }
+    }
+}

--- a/types/kotlin2/Screen.kt
+++ b/types/kotlin2/Screen.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021 New Vector Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.vector.app.features.analytics.plan
+
+import im.vector.app.features.analytics.itf.VectorAnalyticsScreen
+
+// GENERATED FILE, DO NOT EDIT
+
+/**
+ * Triggered when the user changed screen
+ */
+data class Screen(
+    val durationMs: Double? = null,
+    val screenName: ScreenName,
+) : VectorAnalyticsScreen {
+
+    enum class ScreenName {
+        Group,
+        Home,
+        MyGroups,
+        Room,
+        RoomDirectory,
+        User,
+        WebCompleteSecurity,
+        WebE2ESetup,
+        WebForgotPassword,
+        WebLoading,
+        WebLogin,
+        WebRegister,
+        WebSoftLogout,
+        WebWelcome,
+    }
+
+    override fun getName() = screenName.name
+
+    override fun getProperties(): Map<String, Any>? {
+        return mutableMapOf<String, Any>().apply {
+            durationMs?.let { put("durationMs", it) }
+        }.takeIf { it.isNotEmpty() }
+    }
+}


### PR DESCRIPTION
I have written a python script which generates better Kotlin files to be imported into Element Android. Previously generated Kotlin files are still there, the new generated files are created in a dedicated folder.

The new file format has the advantage that new Events can be used more easily, no need to update the Analytics implementation for each new Event.

I have treated the `Screen` event a bit differently, since we have a dedicated API on PostHog, but this is maybe not the best option. We can discuss this if necessary.

At the end, I will create a GitHub action on Element Android to regularly check this project for update Kotlin files and create automatic PR on Element Android. When such PR occurs, the developer will have to integrate the new Event added, or maybe sometimes remove the Event which has been deleted (if used).

The script itself may need some documentation, to ease future maintenance (can be for future me :) )