### PR TITLE
Add support for annotated enums in mobile_generator.py

### DIFF
--- a/schemas/PerformanceTimer.json
+++ b/schemas/PerformanceTimer.json
@@ -8,15 +8,15 @@
     "name": {
       "description": "The timer that is being reported.",
       "type": "string",
-      "enum": [
-        "StartupInitialSync",
-        "StartupIncrementalSync",
-        "StartupStorePreload",
-        "StartupStoreReady",
-        "StartupLaunchScreen",
-        "InitialSyncRequest",
-        "InitialSyncParsing",
-        "NotificationsOpenEvent"
+      "oneOf": [
+        {"enum": ["StartupInitialSync"], "description": "The duration of an initial /sync request during startup (if the store has been wiped)."},
+        {"enum": ["StartupIncrementalSync"], "description": "The duration of a regular /sync request when resuming the app."},
+        {"enum": ["StartupStorePreload"], "description": "The time to preload data in the MXStore on iOS."},
+        {"enum": ["StartupStoreReady"], "description": "The time to load all data from the store (including StartupStorePreload time)."},
+        {"enum": ["StartupLaunchScreen"], "description": "How long the app launch screen is displayed for."},
+        {"enum": ["InitialSyncRequest"], "description": "The time spent waiting for a response to an initial /sync request."},
+        {"enum": ["InitialSyncParsing"], "description": "The time spent parsing the response from an initial /sync request."},
+        {"enum": ["NotificationsOpenEvent"], "description": "The time taken to display an event in the timeline that was opened from a notification."}
       ]
     },
     "timeMs": {

--- a/schemas/PerformanceTimer.json
+++ b/schemas/PerformanceTimer.json
@@ -9,14 +9,14 @@
       "description": "The timer that is being reported.",
       "type": "string",
       "oneOf": [
-        {"enum": ["StartupInitialSync"], "description": "The duration of an initial /sync request during startup (if the store has been wiped)."},
-        {"enum": ["StartupIncrementalSync"], "description": "The duration of a regular /sync request when resuming the app."},
-        {"enum": ["StartupStorePreload"], "description": "The time to preload data in the MXStore on iOS."},
-        {"enum": ["StartupStoreReady"], "description": "The time to load all data from the store (including StartupStorePreload time)."},
-        {"enum": ["StartupLaunchScreen"], "description": "How long the app launch screen is displayed for."},
-        {"enum": ["InitialSyncRequest"], "description": "The time spent waiting for a response to an initial /sync request."},
-        {"enum": ["InitialSyncParsing"], "description": "The time spent parsing the response from an initial /sync request."},
-        {"enum": ["NotificationsOpenEvent"], "description": "The time taken to display an event in the timeline that was opened from a notification."}
+        {"const": "StartupInitialSync", "description": "The duration of an initial /sync request during startup (if the store has been wiped)."},
+        {"const": "StartupIncrementalSync", "description": "The duration of a regular /sync request when resuming the app."},
+        {"const": "StartupStorePreload", "description": "The time to preload data in the MXStore on iOS."},
+        {"const": "StartupStoreReady", "description": "The time to load all data from the store (including StartupStorePreload time)."},
+        {"const": "StartupLaunchScreen", "description": "How long the app launch screen is displayed for."},
+        {"const": "InitialSyncRequest", "description": "The time spent waiting for a response to an initial /sync request."},
+        {"const": "InitialSyncParsing", "description": "The time spent parsing the response from an initial /sync request."},
+        {"const": "NotificationsOpenEvent", "description": "The time taken to display an event in the timeline that was opened from a notification."}
       ]
     },
     "timeMs": {

--- a/scripts/mobile_generator.py
+++ b/scripts/mobile_generator.py
@@ -147,6 +147,12 @@ package im.vector.app.features.analytics.plan
         result += f"    enum class {enum.name} " + "{\n"
         enum.values.sort()
         for value in enum.values:
+            if value.description:
+                result += (
+                    f'        /**\n'
+                    f'         * {value.description}\n'
+                    f'         */\n'
+                )
             result += f"        {value.name},\n"
         result += "    }\n"
         

--- a/scripts/mobile_generator.py
+++ b/scripts/mobile_generator.py
@@ -43,7 +43,7 @@ def make_enum(name, json_property):
             values.append(EnumValue(value, None))
     elif one_of_dict:
         for value in one_of_dict:
-            value_name = value["enum"][0]
+            value_name = value["const"]
             description = value.get('description')
             values.append(EnumValue(value_name, description))
     

--- a/types/kotlin/PerformanceTimer.kt
+++ b/types/kotlin/PerformanceTimer.kt
@@ -33,7 +33,21 @@ enum class EventName {
 }
 
 /**
- * The timer that is being reported.
+ * The duration of an initial /sync request during startup (if the store has been wiped).
+ *
+ * The duration of a regular /sync request when resuming the app.
+ *
+ * The time to preload data in the MXStore on iOS.
+ *
+ * The time to load all data from the store (including StartupStorePreload time).
+ *
+ * How long the app launch screen is displayed for.
+ *
+ * The time spent waiting for a response to an initial /sync request.
+ *
+ * The time spent parsing the response from an initial /sync request.
+ *
+ * The time taken to display an event in the timeline that was opened from a notification.
  */
 enum class Name {
     InitialSyncParsing,

--- a/types/kotlin/PerformanceTimer.kt
+++ b/types/kotlin/PerformanceTimer.kt
@@ -20,7 +20,7 @@ data class PerformanceTimer (
     /**
      * The timer that is being reported.
      */
-    val name: Name,
+    val name: String,
 
     /**
      * The time reported by the timer in milliseconds.
@@ -30,32 +30,4 @@ data class PerformanceTimer (
 
 enum class EventName {
     PerformanceTimer
-}
-
-/**
- * The duration of an initial /sync request during startup (if the store has been wiped).
- *
- * The duration of a regular /sync request when resuming the app.
- *
- * The time to preload data in the MXStore on iOS.
- *
- * The time to load all data from the store (including StartupStorePreload time).
- *
- * How long the app launch screen is displayed for.
- *
- * The time spent waiting for a response to an initial /sync request.
- *
- * The time spent parsing the response from an initial /sync request.
- *
- * The time taken to display an event in the timeline that was opened from a notification.
- */
-enum class Name {
-    InitialSyncParsing,
-    InitialSyncRequest,
-    NotificationsOpenEvent,
-    StartupIncrementalSync,
-    StartupInitialSync,
-    StartupLaunchScreen,
-    StartupStorePreload,
-    StartupStoreReady
 }

--- a/types/kotlin2/PerformanceTimer.kt
+++ b/types/kotlin2/PerformanceTimer.kt
@@ -44,13 +44,37 @@ data class PerformanceTimer(
 ) : VectorAnalyticsEvent {
 
     enum class Name {
+        /**
+         * The time spent parsing the response from an initial /sync request.
+         */
         InitialSyncParsing,
+        /**
+         * The time spent waiting for a response to an initial /sync request.
+         */
         InitialSyncRequest,
+        /**
+         * The time taken to display an event in the timeline that was opened from a notification.
+         */
         NotificationsOpenEvent,
+        /**
+         * The duration of a regular /sync request when resuming the app.
+         */
         StartupIncrementalSync,
+        /**
+         * The duration of an initial /sync request during startup (if the store has been wiped).
+         */
         StartupInitialSync,
+        /**
+         * How long the app launch screen is displayed for.
+         */
         StartupLaunchScreen,
+        /**
+         * The time to preload data in the MXStore on iOS.
+         */
         StartupStorePreload,
+        /**
+         * The time to load all data from the store (including StartupStorePreload time).
+         */
         StartupStoreReady,
     }
 

--- a/types/swift/PerformanceTimer.swift
+++ b/types/swift/PerformanceTimer.swift
@@ -41,13 +41,21 @@ extension AnalyticsEvent {
         }
 
         public enum Name: String {
+            /// The time spent parsing the response from an initial /sync request.
             case InitialSyncParsing
+            /// The time spent waiting for a response to an initial /sync request.
             case InitialSyncRequest
+            /// The time taken to display an event in the timeline that was opened from a notification.
             case NotificationsOpenEvent
+            /// The duration of a regular /sync request when resuming the app.
             case StartupIncrementalSync
+            /// The duration of an initial /sync request during startup (if the store has been wiped).
             case StartupInitialSync
+            /// How long the app launch screen is displayed for.
             case StartupLaunchScreen
+            /// The time to preload data in the MXStore on iOS.
             case StartupStorePreload
+            /// The time to load all data from the store (including StartupStorePreload time).
             case StartupStoreReady
         }
 

--- a/types/typescript/PerformanceTimer.d.ts
+++ b/types/typescript/PerformanceTimer.d.ts
@@ -13,7 +13,7 @@ export interface PerformanceTimer {
   /**
    * The timer that is being reported.
    */
-  name:
+  name: (
     | "StartupInitialSync"
     | "StartupIncrementalSync"
     | "StartupStorePreload"
@@ -21,7 +21,9 @@ export interface PerformanceTimer {
     | "StartupLaunchScreen"
     | "InitialSyncRequest"
     | "InitialSyncParsing"
-    | "NotificationsOpenEvent";
+    | "NotificationsOpenEvent"
+  ) &
+    string;
   /**
    * The time reported by the timer in milliseconds.
    */


### PR DESCRIPTION
I have annotated `PerformanceTimer` and updated the python script. I went for the first `oneOf` style mentioned here in the spec discussion: https://github.com/json-schema-org/json-schema-spec/issues/57#issuecomment-247861695. I've also checked the script using a `oneOf` property with missing descriptions too.

@bmarty I'm unsure if it's possible to add doc comments to Kotlin enum values? If it is, I'm happy to add 🙂

note: The QuickType kotlin generate doesn't like the extra descriptions but we should probably stop generating with that at some point.