### PR TITLE
Add base types for Swift pod compilation.

### DIFF
--- a/AnalyticsEvents.podspec
+++ b/AnalyticsEvents.podspec
@@ -3,19 +3,19 @@
 Pod::Spec.new do |s|
   s.name             = 'AnalyticsEvents'
   s.version          = '0.1.0'
-  s.summary          = 'Cross-platform definitions of analytics events raised by matrix SDKs.'
+  s.summary          = 'Cross-platform definitions of analytics events raised by Matrix SDKs.'
 
   s.description      = <<-DESC
-Auto generated event types for analytics in Element iOS.
+This pod provides the Matrix analytics events generated in Swift.
                        DESC
 
   s.homepage         = "https://www.matrix.org"
   s.license          = { :type => "Apache License, Version 2.0", :file => "LICENSE" }
   s.author           = { "matrix.org" => "support@matrix.org" }
   s.social_media_url = "http://twitter.com/matrixdotorg"
-  s.source           = { :git => 'https://github.com/matrix-org/matrix-analytics-events.git', :tag => s.version.to_s }
+  s.source           = { :git => 'https://github.com/matrix-org/matrix-analytics-events.git', :branch => 'release/swift' }
 
   s.ios.deployment_target = '12.1'
 
-  s.source_files = 'types/swift/**/*.swift'
+  s.source_files = 'types/swift/**/*.swift', 'base_types/swift/**/*.swift'
 end

--- a/base_types/swift/AnalyticsEvent.swift
+++ b/base_types/swift/AnalyticsEvent.swift
@@ -1,0 +1,36 @@
+// 
+// Copyright 2021 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+/// All generated event types are nested inside of this struct.
+public struct AnalyticsEvent { }
+
+/// An event that can be sent to an analytics service.
+public protocol AnalyticsEventProtocol {
+    /// The name of the event being reported.
+    var eventName: String { get }
+    /// A dictionary containing all additional properties that are reported.
+    var properties: [String: Any] { get }
+}
+
+/// An event that can be sent to an analytics service which represents the display of a screen .
+public protocol AnalyticsScreenProtocol {
+    /// The name of the event being reported.
+    var screenName: AnalyticsEvent.Screen.ScreenName { get }
+    /// A dictionary containing all additional properties that are reported.
+    var properties: [String: Any] { get }
+}


### PR DESCRIPTION
Small PR that adds a `base_types` directory when each language can add any required source files to be distributed alongside the generated events (I think this may only be necessary with Swift for now).

Also updates the podspec to add these and with a plan of maintaining a `release/swift` branch that element-ios will use for its dependency.