### PR TITLE
Make Swift's dictionary values into optionals

### DIFF
--- a/base_types/swift/AnalyticsEvent.swift
+++ b/base_types/swift/AnalyticsEvent.swift
@@ -24,7 +24,7 @@ public protocol AnalyticsEventProtocol {
     /// The name of the event being reported.
     var eventName: String { get }
     /// A dictionary containing all additional properties that are reported.
-    var properties: [String: Any] { get }
+    var properties: [String: Any?] { get }
 }
 
 /// An event that can be sent to an analytics service which represents the display of a screen .
@@ -32,5 +32,5 @@ public protocol AnalyticsScreenProtocol {
     /// The name of the event being reported.
     var screenName: AnalyticsEvent.Screen.ScreenName { get }
     /// A dictionary containing all additional properties that are reported.
-    var properties: [String: Any] { get }
+    var properties: [String: Any?] { get }
 }

--- a/stub-generator/matrix_analytics_stub_generator/swift.py
+++ b/stub-generator/matrix_analytics_stub_generator/swift.py
@@ -97,24 +97,24 @@ def compute_swift(schema: Schema) -> str:
     # Properties dictionary
     result += "\n"
     if not schema.members:
-        result += "        public var properties: [String: Any] = [:]\n"
+        result += "        public var properties: [String: Any?] = [:]\n"
     else:
         filtered_members = list(
             filter(lambda member: member.name != "screenName", schema.members)
         )
-        result += "        public var properties: [String: Any] {\n"
+        result += "        public var properties: [String: Any?] {\n"
         result += "            return [\n"
         for index, member in enumerate(filtered_members):
             if member.enum:
                 if member.required:
                     result += f'                "{member.name}": {member.name}.rawValue'
                 else:
-                    result += f'                "{member.name}": {member.name}?.rawValue as Any'  # noqa
+                    result += f'                "{member.name}": {member.name}?.rawValue'  # noqa
             else:
                 if member.required:
                     result += f'                "{member.name}": {member.name}'
                 else:
-                    result += f'                "{member.name}": {member.name} as Any'
+                    result += f'                "{member.name}": {member.name}'
             if index < len(filtered_members) - 1:
                 result += ",\n"
             else:

--- a/types/swift/CallEnded.swift
+++ b/types/swift/CallEnded.swift
@@ -40,7 +40,7 @@ extension AnalyticsEvent {
             self.placed = placed
         }
 
-        public var properties: [String: Any] {
+        public var properties: [String: Any?] {
             return [
                 "durationMs": durationMs,
                 "isVideo": isVideo,

--- a/types/swift/CallError.swift
+++ b/types/swift/CallError.swift
@@ -37,7 +37,7 @@ extension AnalyticsEvent {
             self.placed = placed
         }
 
-        public var properties: [String: Any] {
+        public var properties: [String: Any?] {
             return [
                 "isVideo": isVideo,
                 "numParticipants": numParticipants,

--- a/types/swift/CallStarted.swift
+++ b/types/swift/CallStarted.swift
@@ -37,7 +37,7 @@ extension AnalyticsEvent {
             self.placed = placed
         }
 
-        public var properties: [String: Any] {
+        public var properties: [String: Any?] {
             return [
                 "isVideo": isVideo,
                 "numParticipants": numParticipants,

--- a/types/swift/Click.swift
+++ b/types/swift/Click.swift
@@ -38,9 +38,9 @@ extension AnalyticsEvent {
             case SendMessageButton
         }
 
-        public var properties: [String: Any] {
+        public var properties: [String: Any?] {
             return [
-                "index": index as Any,
+                "index": index,
                 "name": name.rawValue
             ]
         }

--- a/types/swift/CreatedRoom.swift
+++ b/types/swift/CreatedRoom.swift
@@ -31,7 +31,7 @@ extension AnalyticsEvent {
             self.isDM = isDM
         }
 
-        public var properties: [String: Any] {
+        public var properties: [String: Any?] {
             return [
                 "isDM": isDM
             ]

--- a/types/swift/Error.swift
+++ b/types/swift/Error.swift
@@ -52,9 +52,9 @@ extension AnalyticsEvent {
             case VoipUserMediaFailed
         }
 
-        public var properties: [String: Any] {
+        public var properties: [String: Any?] {
             return [
-                "context": context as Any,
+                "context": context,
                 "domain": domain.rawValue,
                 "name": name.rawValue
             ]

--- a/types/swift/Identify.swift
+++ b/types/swift/Identify.swift
@@ -42,9 +42,9 @@ extension AnalyticsEvent {
             case WorkMessaging
         }
 
-        public var properties: [String: Any] {
+        public var properties: [String: Any?] {
             return [
-                "ftueUseCaseSelection": ftueUseCaseSelection?.rawValue as Any
+                "ftueUseCaseSelection": ftueUseCaseSelection?.rawValue
             ]
         }
     }

--- a/types/swift/JoinedRoom.swift
+++ b/types/swift/JoinedRoom.swift
@@ -42,7 +42,7 @@ extension AnalyticsEvent {
             case Two
         }
 
-        public var properties: [String: Any] {
+        public var properties: [String: Any?] {
             return [
                 "isDM": isDM,
                 "roomSize": roomSize.rawValue

--- a/types/swift/PerformanceTimer.swift
+++ b/types/swift/PerformanceTimer.swift
@@ -59,10 +59,10 @@ extension AnalyticsEvent {
             case StartupStoreReady
         }
 
-        public var properties: [String: Any] {
+        public var properties: [String: Any?] {
             return [
-                "context": context as Any,
-                "itemCount": itemCount as Any,
+                "context": context,
+                "itemCount": itemCount,
                 "name": name.rawValue,
                 "timeMs": timeMs
             ]

--- a/types/swift/Screen.swift
+++ b/types/swift/Screen.swift
@@ -115,9 +115,9 @@ extension AnalyticsEvent {
             case Welcome
         }
 
-        public var properties: [String: Any] {
+        public var properties: [String: Any?] {
             return [
-                "durationMs": durationMs as Any
+                "durationMs": durationMs
             ]
         }
     }

--- a/types/swift/UnauthenticatedError.swift
+++ b/types/swift/UnauthenticatedError.swift
@@ -46,7 +46,7 @@ extension AnalyticsEvent {
             case M_UNKNOWN_TOKEN
         }
 
-        public var properties: [String: Any] {
+        public var properties: [String: Any?] {
             return [
                 "errorCode": errorCode.rawValue,
                 "errorReason": errorReason,


### PR DESCRIPTION
Small tweak to the generator and protocols which will allow calling `compactMapValues` to filter out anything that is `nil`.