### PR TITLE
Escaping kotlin $ char in event names

### DIFF
--- a/stub-generator/matrix_analytics_stub_generator/kotlin.py
+++ b/stub-generator/matrix_analytics_stub_generator/kotlin.py
@@ -86,7 +86,7 @@ package im.vector.app.features.analytics.plan
     if is_screen:
         result += "    override fun getName() = screenName.name\n"
     else:
-        result += f'    override fun getName() = "{schema.event_name}"\n'
+        result += f'    override fun getName() = "{escape_event_name(schema.event_name)}"\n'
 
     result += "\n"
     if not schema.members:
@@ -118,3 +118,6 @@ package im.vector.app.features.analytics.plan
 
     result += "}\n"
     return result
+
+def escape_event_name(event_name: str) -> str:
+    return event_name.replace("$", "\$")

--- a/stub-generator/matrix_analytics_stub_generator/kotlin.py
+++ b/stub-generator/matrix_analytics_stub_generator/kotlin.py
@@ -121,3 +121,4 @@ package im.vector.app.features.analytics.plan
 
 def escape_event_name(event_name: str) -> str:
     return event_name.replace("$", "\$")
+    

--- a/types/kotlin2/Identify.kt
+++ b/types/kotlin2/Identify.kt
@@ -54,7 +54,7 @@ data class Identify(
         WorkMessaging,
     }
 
-    override fun getName() = "$identify"
+    override fun getName() = "\$identify"
 
     override fun getProperties(): Map<String, Any>? {
         return mutableMapOf<String, Any>().apply {


### PR DESCRIPTION
`$` is used for the string interpolation in kotlin

```kotlin
val foo = "foo"
"$bar"
```

This PR naively replaces all `$` instances with `\$` 