### PR TITLE
Remove protocol conformance on Swift UserProperties

### DIFF
--- a/stub-generator/matrix_analytics_stub_generator/swift.py
+++ b/stub-generator/matrix_analytics_stub_generator/swift.py
@@ -23,6 +23,31 @@ def swift_member_definition(member: Member) -> str:
 
     return definition
 
+def swift_properties_type(protocol) -> str:
+    # Event protocols don't need optional values and will cast nil to Any
+    if protocol:
+        return "[String: Any]"
+    else:
+        return "[String: Any?]"
+
+def swift_member_property(member: Member, protocol) -> str:
+    if member.enum:
+        if member.required:
+            property = f'"{member.name}": {member.name}.rawValue'
+        elif protocol:
+            # Silence compiler warning with cast of Optional to Any
+            property = f'"{member.name}": {member.name}?.rawValue as Any'
+        else:
+            property = f'"{member.name}": {member.name}?.rawValue'
+    else:
+        if not member.required and protocol:
+            # Silence compiler warning with cast of Optional to Any
+            property = f'"{member.name}": {member.name} as Any'
+        else:
+            property = f'"{member.name}": {member.name}'
+    
+    return property
+
 
 def compute_swift(schema: Schema) -> str:
     """Compute the output for Swift."""
@@ -47,9 +72,11 @@ def compute_swift(schema: Schema) -> str:
 """
 
     if is_screen:
-        itf = "AnalyticsScreenProtocol"
+        protocol = "AnalyticsScreenProtocol"
+    elif schema.event_name:
+        protocol = "AnalyticsEventProtocol"
     else:
-        itf = "AnalyticsEventProtocol"
+        protocol = None
 
     result += (
         "import Foundation\n\n"
@@ -57,8 +84,13 @@ def compute_swift(schema: Schema) -> str:
         "// https://github.com/matrix-org/matrix-analytics-events/\n\n"
         f"/// {schema.data.get('description')}\n"
         f"extension AnalyticsEvent {{\n"
-        f"    public struct {schema.klass}: {itf} {{\n"
     )
+    
+    # Protocol conformance
+    if protocol:
+        result += f"    public struct {schema.klass}: {protocol} {{\n"
+    else:
+        result += f"    public struct {schema.klass} {{\n"
 
     # Event name (constant)
     if not is_screen and schema.event_name:
@@ -97,24 +129,15 @@ def compute_swift(schema: Schema) -> str:
     # Properties dictionary
     result += "\n"
     if not schema.members:
-        result += "        public var properties: [String: Any] = [:]\n"
+        result += f"        public var properties: {swift_properties_type(protocol)} = [:]\n"
     else:
         filtered_members = list(
             filter(lambda member: member.name != "screenName", schema.members)
         )
-        result += "        public var properties: [String: Any] {\n"
+        result += f"        public var properties: {swift_properties_type(protocol)} {{\n"
         result += "            return [\n"
         for index, member in enumerate(filtered_members):
-            if member.enum:
-                if member.required:
-                    result += f'                "{member.name}": {member.name}.rawValue'
-                else:
-                    result += f'                "{member.name}": {member.name}?.rawValue as Any'  # noqa
-            else:
-                if member.required:
-                    result += f'                "{member.name}": {member.name}'
-                else:
-                    result += f'                "{member.name}": {member.name} as Any'
+            result += f'                {swift_member_property(member, protocol)}'
             if index < len(filtered_members) - 1:
                 result += ",\n"
             else:

--- a/types/swift/UserProperties.swift
+++ b/types/swift/UserProperties.swift
@@ -21,7 +21,7 @@ import Foundation
 
 /// The user properties to apply when identifying. This is not an event definition. These properties must all be device independent.
 extension AnalyticsEvent {
-    public struct UserProperties: AnalyticsEventProtocol {
+    public struct UserProperties {
 
         /// The selected messaging use case during the onboarding flow.
         public let ftueUseCaseSelection: FtueUseCaseSelection?
@@ -44,10 +44,10 @@ extension AnalyticsEvent {
             case WorkMessaging
         }
 
-        public var properties: [String: Any] {
+        public var properties: [String: Any?] {
             return [
-                "ftueUseCaseSelection": ftueUseCaseSelection?.rawValue as Any,
-                "numSpaces": numSpaces as Any
+                "ftueUseCaseSelection": ftueUseCaseSelection?.rawValue,
+                "numSpaces": numSpaces
             ]
         }
     }


### PR DESCRIPTION
Small tweak to the swift generator for #28. Additionally implements the required changes from #25 for any generated structs that don't conform to an event protocol.