### PR TITLE
add WebHomeMiniAvatarUploadButton Interaction

### DIFF
--- a/schemas/Interaction.json
+++ b/schemas/Interaction.json
@@ -44,7 +44,7 @@
         {"const": "WebRoomListHeaderPlusMenuCreateChatItem", "description": "User clicked the create DM button in the + context menu of the room list header in Element Web/Desktop." },
         {"const": "WebSpaceContextMenuHomeItem", "description": "User clicked the home button in the context menu of a space in Element Web/Desktop." },
         {"const": "WebHomeExploreRoomsButton", "description": "User clicked the explore rooms button in the home page of Element Web/Desktop." },
-        {"const": "WebHomeMiniAvatarUploadButton", "description": "User updated their avatar via the mini avatar uploader in the home page of Element Web/Desktop." },
+        {"const": "WebHomeMiniAvatarUploadButton", "description": "User clicked on the mini avatar uploader in the home page of Element Web/Desktop." },
         {"const": "WebLeftPanelExploreRoomsButton", "description": "User clicked the explore rooms button next to the search field at the top of the left panel in Element Web/Desktop." },
         {"const": "WebSpaceContextMenuExploreRoomsItem", "description": "User clicked the explore rooms button in the context menu of a space in Element Web/Desktop." },
         {"const": "WebRoomListHeaderPlusMenuExploreRoomsItem", "description": "User clicked the explore rooms button in the + context menu of the room list header in Element Web/Desktop." },

--- a/schemas/Interaction.json
+++ b/schemas/Interaction.json
@@ -44,6 +44,7 @@
         {"const": "WebRoomListHeaderPlusMenuCreateChatItem", "description": "User clicked the create DM button in the + context menu of the room list header in Element Web/Desktop." },
         {"const": "WebSpaceContextMenuHomeItem", "description": "User clicked the home button in the context menu of a space in Element Web/Desktop." },
         {"const": "WebHomeExploreRoomsButton", "description": "User clicked the explore rooms button in the home page of Element Web/Desktop." },
+        {"const": "WebHomeMiniAvatarUploadButton", "description": "User updated their avatar via the mini avatar uploader in the home page of Element Web/Desktop." },
         {"const": "WebLeftPanelExploreRoomsButton", "description": "User clicked the explore rooms button next to the search field at the top of the left panel in Element Web/Desktop." },
         {"const": "WebSpaceContextMenuExploreRoomsItem", "description": "User clicked the explore rooms button in the context menu of a space in Element Web/Desktop." },
         {"const": "WebRoomListHeaderPlusMenuExploreRoomsItem", "description": "User clicked the explore rooms button in the + context menu of the room list header in Element Web/Desktop." },

--- a/types/html/index.html
+++ b/types/html/index.html
@@ -1381,6 +1381,12 @@
                                         
                                             <li>
                                                 
+                                                    <b>WebHomeMiniAvatarUploadButton:</b> User updated their avatar via the mini avatar uploader in the home page of Element Web/Desktop.
+                                                    
+                                            </li>
+                                        
+                                            <li>
+                                                
                                                     <b>WebLeftPanelExploreRoomsButton:</b> User clicked the explore rooms button next to the search field at the top of the left panel in Element Web/Desktop.
                                                     
                                             </li>

--- a/types/html/index.html
+++ b/types/html/index.html
@@ -1381,7 +1381,7 @@
                                         
                                             <li>
                                                 
-                                                    <b>WebHomeMiniAvatarUploadButton:</b> User updated their avatar via the mini avatar uploader in the home page of Element Web/Desktop.
+                                                    <b>WebHomeMiniAvatarUploadButton:</b> User clicked on the mini avatar uploader in the home page of Element Web/Desktop.
                                                     
                                             </li>
                                         

--- a/types/kotlin2/Interaction.kt
+++ b/types/kotlin2/Interaction.kt
@@ -106,6 +106,12 @@ data class Interaction(
         WebHomeExploreRoomsButton,
 
         /**
+         * User updated their avatar via the mini avatar uploader in the home
+         * page of Element Web/Desktop.
+         */
+        WebHomeMiniAvatarUploadButton,
+
+        /**
          * User clicked the explore rooms button next to the search field at the
          * top of the left panel in Element Web/Desktop.
          */

--- a/types/kotlin2/Interaction.kt
+++ b/types/kotlin2/Interaction.kt
@@ -106,8 +106,8 @@ data class Interaction(
         WebHomeExploreRoomsButton,
 
         /**
-         * User updated their avatar via the mini avatar uploader in the home
-         * page of Element Web/Desktop.
+         * User clicked on the mini avatar uploader in the home page of Element
+         * Web/Desktop.
          */
         WebHomeMiniAvatarUploadButton,
 

--- a/types/swift/Interaction.swift
+++ b/types/swift/Interaction.swift
@@ -62,7 +62,7 @@ extension AnalyticsEvent {
             case WebHomeCreateRoomButton
             /// User clicked the explore rooms button in the home page of Element Web/Desktop.
             case WebHomeExploreRoomsButton
-            /// User updated their avatar via the mini avatar uploader in the home page of Element Web/Desktop.
+            /// User clicked on the mini avatar uploader in the home page of Element Web/Desktop.
             case WebHomeMiniAvatarUploadButton
             /// User clicked the explore rooms button next to the search field at the top of the left panel in Element Web/Desktop.
             case WebLeftPanelExploreRoomsButton

--- a/types/swift/Interaction.swift
+++ b/types/swift/Interaction.swift
@@ -62,6 +62,8 @@ extension AnalyticsEvent {
             case WebHomeCreateRoomButton
             /// User clicked the explore rooms button in the home page of Element Web/Desktop.
             case WebHomeExploreRoomsButton
+            /// User updated their avatar via the mini avatar uploader in the home page of Element Web/Desktop.
+            case WebHomeMiniAvatarUploadButton
             /// User clicked the explore rooms button next to the search field at the top of the left panel in Element Web/Desktop.
             case WebLeftPanelExploreRoomsButton
             /// User interacted with pin to sidebar checkboxes in the quick settings menu of Element Web/Desktop.

--- a/types/typescript/Interaction.d.ts
+++ b/types/typescript/Interaction.d.ts
@@ -49,6 +49,7 @@ export interface Interaction {
     | "WebRoomListHeaderPlusMenuCreateChatItem"
     | "WebSpaceContextMenuHomeItem"
     | "WebHomeExploreRoomsButton"
+    | "WebHomeMiniAvatarUploadButton"
     | "WebLeftPanelExploreRoomsButton"
     | "WebSpaceContextMenuExploreRoomsItem"
     | "WebRoomListHeaderPlusMenuExploreRoomsItem"


### PR DESCRIPTION
Related: https://github.com/vector-im/element-web/issues/21946
Dependents: https://github.com/matrix-org/matrix-react-sdk/pull/8474

## In Short
* Adds new WebHomeMiniAvatarUploadButton interaction