### PR TITLE
Ensure generated Kotlin code follow Kotlin naming convention

### DIFF
--- a/stub-generator/matrix_analytics_stub_generator/kotlin.py
+++ b/stub-generator/matrix_analytics_stub_generator/kotlin.py
@@ -1,4 +1,4 @@
-from .schema import Schema, is_mobile_screen_event, first_letter_up, split_text
+from .schema import Schema, is_mobile_screen_event, first_letter_up, first_letter_down, split_text
 
 def compute_kotlin(schema: Schema) -> str:
     """Compute the output for Kotlin."""
@@ -44,6 +44,7 @@ package im.vector.app.features.analytics.plan
     )
 
     for member in schema.members:
+        validName = first_letter_down(member.name)
         if member.description:
             result += f"        /**\n"
             result += f"{split_text('         * ', member.description)}\n"
@@ -55,15 +56,15 @@ package im.vector.app.features.analytics.plan
         result += "        "
         if member.type == "string":
             if member.enum:
-                result += f"val {member.name}: {first_letter_up(member.name)}"
+                result += f"val {validName}: {first_letter_up(member.name)}"
             else:
-                result += f"val {member.name}: String"
+                result += f"val {validName}: String"
         elif member.type == "number":
-            result += f"val {member.name}: Double"
+            result += f"val {validName}: Double"
         elif member.type == "integer":
-            result += f"val {member.name}: Int"
+            result += f"val {validName}: Int"
         elif member.type == "boolean":
-            result += f"val {member.name}: Boolean"
+            result += f"val {validName}: Boolean"
         else:
             raise Exception(f"Not handled yet: {member.type}")
         result += f"{defaultValue},\n"
@@ -107,22 +108,24 @@ package im.vector.app.features.analytics.plan
 
         result += "        return mutableMapOf<String, Any>().apply {\n"
         for member in schema.members:
+            validName = first_letter_down(member.name)
+
             if member.name == "screenName" and is_screen:
                 continue
             if member.required:
                 if member.enum:
-                    result += f'            put("{member.name}", {member.name}.name)\n'
+                    result += f'            put("{validName}", {member.name}.name)\n'
                 else:
-                    result += f'            put("{member.name}", {member.name})\n'
+                    result += f'            put("{validName}", {member.name})\n'
             else:
                 if member.enum:
                     result += '            %s?.let { put("%s", it.name) }\n' % (
-                        member.name,
+                        validName,
                         member.name,
                     )
                 else:
                     result += '            %s?.let { put("%s", it) }\n' % (
-                        member.name,
+                        validName,
                         member.name,
                     )
         result += "        }.takeIf { it.isNotEmpty() }\n"

--- a/stub-generator/matrix_analytics_stub_generator/schema.py
+++ b/stub-generator/matrix_analytics_stub_generator/schema.py
@@ -44,6 +44,10 @@ def first_letter_up(s: str) -> str:
     """capitalize() can also change the next letter, and I want to keep camel case."""
     return s[0].upper() + s[1:]
 
+def first_letter_down(s: str) -> str:
+    """Ensure the first letter is not upper case."""
+    return s[0].lower() + s[1:]
+
 def split_text(prefix: str, text: str, limit: int = 80):
     """ensure comment is limited in length"""
     # Use str() to avoid this issue: AttributeError: 'set' object has no attribute 'expandtabs'

--- a/types/kotlin2/UserProperties.kt
+++ b/types/kotlin2/UserProperties.kt
@@ -27,23 +27,23 @@ data class UserProperties(
         /**
          * Whether the user has the favourites space enabled
          */
-        val WebMetaSpaceFavouritesEnabled: Boolean? = null,
+        val webMetaSpaceFavouritesEnabled: Boolean? = null,
         /**
          * Whether the user has the home space set to all rooms
          */
-        val WebMetaSpaceHomeAllRooms: Boolean? = null,
+        val webMetaSpaceHomeAllRooms: Boolean? = null,
         /**
          * Whether the user has the home space enabled
          */
-        val WebMetaSpaceHomeEnabled: Boolean? = null,
+        val webMetaSpaceHomeEnabled: Boolean? = null,
         /**
          * Whether the user has the other rooms space enabled
          */
-        val WebMetaSpaceOrphansEnabled: Boolean? = null,
+        val webMetaSpaceOrphansEnabled: Boolean? = null,
         /**
          * Whether the user has the people space enabled
          */
-        val WebMetaSpacePeopleEnabled: Boolean? = null,
+        val webMetaSpacePeopleEnabled: Boolean? = null,
         /**
          * The selected messaging use case during the onboarding flow.
          */
@@ -82,11 +82,11 @@ data class UserProperties(
 
     fun getProperties(): Map<String, Any>? {
         return mutableMapOf<String, Any>().apply {
-            WebMetaSpaceFavouritesEnabled?.let { put("WebMetaSpaceFavouritesEnabled", it) }
-            WebMetaSpaceHomeAllRooms?.let { put("WebMetaSpaceHomeAllRooms", it) }
-            WebMetaSpaceHomeEnabled?.let { put("WebMetaSpaceHomeEnabled", it) }
-            WebMetaSpaceOrphansEnabled?.let { put("WebMetaSpaceOrphansEnabled", it) }
-            WebMetaSpacePeopleEnabled?.let { put("WebMetaSpacePeopleEnabled", it) }
+            webMetaSpaceFavouritesEnabled?.let { put("WebMetaSpaceFavouritesEnabled", it) }
+            webMetaSpaceHomeAllRooms?.let { put("WebMetaSpaceHomeAllRooms", it) }
+            webMetaSpaceHomeEnabled?.let { put("WebMetaSpaceHomeEnabled", it) }
+            webMetaSpaceOrphansEnabled?.let { put("WebMetaSpaceOrphansEnabled", it) }
+            webMetaSpacePeopleEnabled?.let { put("WebMetaSpacePeopleEnabled", it) }
             ftueUseCaseSelection?.let { put("ftueUseCaseSelection", it.name) }
             numFavouriteRooms?.let { put("numFavouriteRooms", it) }
             numSpaces?.let { put("numSpaces", it) }


### PR DESCRIPTION
Constructor parameters cannot start by an upper case letter.
This PR fixes that, hopefully without any side effect on the sent analytics, and on the other generated code.