### PR TITLE
Add ViewRoom.Shortcut, for rooms opened via a shortcut.

### DIFF
--- a/schemas/ViewRoom.json
+++ b/schemas/ViewRoom.json
@@ -22,6 +22,7 @@
         {"const": "MessageUser", "description": "Room switched due to user selecting a user to go to a DM with."},
         {"const": "VerificationRequest", "description": "Room switched due to user interacting with incoming verification request."},
         {"const": "SlashCommand", "description": "Room accessed via a slash command in Element Web/Desktop like /goto."},
+        {"const": "Shortcut", "description": "Room accessed via a shortcut."},
 
         {"const": "WebNotificationPanel", "description": "Room accessed via Element Web/Desktop's notification panel."},
         {"const": "WebKeyboardShortcut", "description": "Room accessed via an Element Web/Desktop keyboard shortcut like go to next room with unread messages."},

--- a/types/kotlin2/ViewRoom.kt
+++ b/types/kotlin2/ViewRoom.kt
@@ -153,6 +153,11 @@ data class ViewRoom(
         RoomList,
 
         /**
+         * Room accessed via a shortcut.
+         */
+        Shortcut,
+
+        /**
          * Room accessed via a slash command in Element Web/Desktop like /goto.
          */
         SlashCommand,

--- a/types/swift/ViewRoom.swift
+++ b/types/swift/ViewRoom.swift
@@ -84,6 +84,8 @@ extension AnalyticsEvent {
             case RoomDirectory
             /// Room accessed via the room list.
             case RoomList
+            /// Room accessed via a shortcut.
+            case Shortcut
             /// Room accessed via a slash command in Element Web/Desktop like /goto.
             case SlashCommand
             /// Room accessed via the space hierarchy view.


### PR DESCRIPTION
Element Android give the possibility to add a shortcut for a Room. This new event will allow us to track this.

I am not sure, but no change has been done for Web data.
I have invoked

```shell
scripts/setup.sh
yarn build
```

Let me know if I missed something.