### PR TITLE
Add support for Swift Package Manager.

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,27 @@
+name: Validate Swift
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    concurrency:
+      # When running on main, use the sha to allow all runs of this workflow to run concurrently.
+      # Otherwise only allow a single run of this workflow on each branch, automatically cancelling older runs.
+      group: ${{ github.ref == 'refs/heads/main' && format('swift-main-{0}', github.sha) || format('swift-{0}', github.ref) }}
+      cancel-in-progress: true
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Swift
+      uses: slashmo/install-swift@v0.2.1
+      with:
+        version: 5.6
+
+    - name: Build for Swift
+      run: swift build

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .npmrc
 node_modules/
 .DS_Store
+.swiftpm
+.build
 /types/html
 /types/typescript

--- a/AnalyticsEvents.podspec
+++ b/AnalyticsEvents.podspec
@@ -17,5 +17,5 @@ This pod provides the Matrix analytics events generated in Swift.
 
   s.ios.deployment_target = '12.1'
 
-  s.source_files = 'types/swift/**/*.swift', 'base_types/swift/**/*.swift'
+  s.source_files = 'types/swift/**/*.swift'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 5.6
+
+import PackageDescription
+
+let package = Package(
+    name: "AnalyticsEvents",
+    products: [
+        .library(name: "AnalyticsEvents", targets: ["AnalyticsEvents"])
+    ],
+    targets: [
+        .target(name: "AnalyticsEvents", path: "types/swift")
+    ]
+)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build:ts": "./scripts/build-typescript.sh",
     "build:kt": "./scripts/build-kotlin.sh",
     "build:kt2": "cd stub-generator && poetry run python -m matrix_analytics_stub_generator -l kotlin -o ../types/kotlin2 -i ../schemas",
-    "build:swift": "cd stub-generator && poetry run python -m matrix_analytics_stub_generator -l swift -o ../types/swift -i ../schemas",
+    "build:swift": "cd stub-generator && poetry run python -m matrix_analytics_stub_generator -l swift -o ../types/swift -i ../schemas && cp ../base_types/swift/* ../types/swift/",
     "build:html": "cd stub-generator && poetry run python -m matrix_analytics_stub_generator -l html -o ../types/html -i ../schemas"
   }
 }

--- a/types/swift/AnalyticsEvent.swift
+++ b/types/swift/AnalyticsEvent.swift
@@ -1,0 +1,36 @@
+// 
+// Copyright 2021 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+/// All generated event types are nested inside of this struct.
+public struct AnalyticsEvent { }
+
+/// An event that can be sent to an analytics service.
+public protocol AnalyticsEventProtocol {
+    /// The name of the event being reported.
+    var eventName: String { get }
+    /// A dictionary containing all additional properties that are reported.
+    var properties: [String: Any] { get }
+}
+
+/// An event that can be sent to an analytics service which represents the display of a screen .
+public protocol AnalyticsScreenProtocol {
+    /// The name of the event being reported.
+    var screenName: AnalyticsEvent.MobileScreen.ScreenName { get }
+    /// A dictionary containing all additional properties that are reported.
+    var properties: [String: Any] { get }
+}


### PR DESCRIPTION
This PR adds the following:
- Package.swift for SwiftPM support
- Copies `base_types/swift` into `types/swift` after stub generation to have a single path for all Swift files.
- Adds a GitHub action that will build the files for Swift on every PR or push to `main` ([#40](https://github.com/matrix-org/matrix-analytics-events/issues/40)).