### PR TITLE
Update Swift on CI.

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     concurrency:
       # When running on main, use the sha to allow all runs of this workflow to run concurrently.
@@ -19,9 +19,9 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install Swift
-      uses: slashmo/install-swift@v0.2.1
+      uses: slashmo/install-swift@v0.3.0
       with:
-        version: 5.6
+        version: 5.7
 
     - name: Build for Swift
       run: swift build


### PR DESCRIPTION
The Swift CI check is failing. This PR updates the install-swift action and uses the latest version of Swift <del>which should be available for the latest version of Ubuntu.</del>, but this seemingly still fails on Ubuntu 22.04 so I've pinned to Ubuntu 20.04 which works fine.