### PR TITLE
Threads Activity Centre analytics

### DIFF
--- a/schemas/Interaction.json
+++ b/schemas/Interaction.json
@@ -55,6 +55,7 @@
         {"const": "WebThreadViewBackButton", "description": "User clicked the back button on a Thread view going back to the Threads Panel of Element Web/Desktop." },
         {"const": "WebThreadsPanelThreadItem", "description": "User selected a thread in the Threads panel in Element Web/Desktop." },
         {"const": "WebThreadsActivityCentreButton", "description": "User clicked on the Threads Activity Centre button of Element Web/Desktop." },
+        {"const": "WebThreadsActivityCentreRoomItem", "description": "User clicked on a room in the Threads Activity Centre of Element Web/Desktop." },
         {"const": "WebRoomTimelineThreadSummaryButton", "description": "User clicked a thread summary in the timeline of a room in Element Web/Desktop." },
         {"const": "WebUserOnboardingHeaderSendDm", "description": "User clicked on the send DM CTA in the header of the new user onboarding page in Element Web/Desktop." },
         {"const": "WebUserOnboardingTaskSendDm", "description": "User clicked on the action of the find people task on the new user onboarding page in Element Web/Desktop." },

--- a/schemas/Interaction.json
+++ b/schemas/Interaction.json
@@ -54,6 +54,7 @@
         {"const": "WebRoomHeaderButtonsThreadsButton", "description": "User clicked the Threads button in the top right of a room in Element Web/Desktop." },
         {"const": "WebThreadViewBackButton", "description": "User clicked the back button on a Thread view going back to the Threads Panel of Element Web/Desktop." },
         {"const": "WebThreadsPanelThreadItem", "description": "User selected a thread in the Threads panel in Element Web/Desktop." },
+        {"const": "WebThreadsActivityCentreButton", "description": "User clicked on the Threads Activity Centre button of Element Web/Desktop." },
         {"const": "WebRoomTimelineThreadSummaryButton", "description": "User clicked a thread summary in the timeline of a room in Element Web/Desktop." },
         {"const": "WebUserOnboardingHeaderSendDm", "description": "User clicked on the send DM CTA in the header of the new user onboarding page in Element Web/Desktop." },
         {"const": "WebUserOnboardingTaskSendDm", "description": "User clicked on the action of the find people task on the new user onboarding page in Element Web/Desktop." },

--- a/schemas/ViewRoom.json
+++ b/schemas/ViewRoom.json
@@ -37,6 +37,7 @@
         {"const": "WebRoomListNotificationBadge", "description": "Room accessed via clicking on a notifications badge on a room list sublist in Element Web/Desktop."},
         {"const": "WebSpacePanelNotificationBadge", "description": "Room accessed via clicking on the notifications badge on the currently selected space in Element Web/Desktop."},
         {"const": "WebFloatingCallWindow", "description": "Room accessed via interacting with the floating call or Jitsi PIP in Element Web/Desktop."},
+        {"const": "WebThreadsActivityCentre", "description": "Room accessed via interacting with the Threads Activity Centre in Element Web/Desktop."},
 
         {"const": "MobileFileSearch", "description": "Room switched due to user interacting with a file search result."},
         {"const": "MobileRoomSearch", "description": "Room switched due to user interacting with a room search result."},

--- a/types/kotlin2/Interaction.kt
+++ b/types/kotlin2/Interaction.kt
@@ -409,6 +409,18 @@ data class Interaction(
         WebThreadViewBackButton,
 
         /**
+         * User clicked on the Threads Activity Centre button of Element
+         * Web/Desktop.
+         */
+        WebThreadsActivityCentreButton,
+
+        /**
+         * User clicked on a room in the Threads Activity Centre of Element
+         * Web/Desktop.
+         */
+        WebThreadsActivityCentreRoomItem,
+
+        /**
          * User selected a thread in the Threads panel in Element Web/Desktop.
          */
         WebThreadsPanelThreadItem,

--- a/types/kotlin2/ViewRoom.kt
+++ b/types/kotlin2/ViewRoom.kt
@@ -253,6 +253,12 @@ data class ViewRoom(
         WebSpacePanelNotificationBadge,
 
         /**
+         * Room accessed via interacting with the Threads Activity Centre in
+         * Element Web/Desktop.
+         */
+        WebThreadsActivityCentre,
+
+        /**
          * Room accessed via Element Web/Desktop's Unified Search modal.
          */
         WebUnifiedSearch,

--- a/types/swift/Interaction.swift
+++ b/types/swift/Interaction.swift
@@ -166,6 +166,10 @@ extension AnalyticsEvent {
             case WebSpaceHomeCreateRoomButton
             /// User clicked the back button on a Thread view going back to the Threads Panel of Element Web/Desktop.
             case WebThreadViewBackButton
+            /// User clicked on the Threads Activity Centre button of Element Web/Desktop.
+            case WebThreadsActivityCentreButton
+            /// User clicked on a room in the Threads Activity Centre of Element Web/Desktop.
+            case WebThreadsActivityCentreRoomItem
             /// User selected a thread in the Threads panel in Element Web/Desktop.
             case WebThreadsPanelThreadItem
             /// User clicked the theme toggle button in the user menu of Element Web/Desktop.

--- a/types/swift/ViewRoom.swift
+++ b/types/swift/ViewRoom.swift
@@ -120,6 +120,8 @@ extension AnalyticsEvent {
             case WebSpaceContextSwitch
             /// Room accessed via clicking on the notifications badge on the currently selected space in Element Web/Desktop.
             case WebSpacePanelNotificationBadge
+            /// Room accessed via interacting with the Threads Activity Centre in Element Web/Desktop.
+            case WebThreadsActivityCentre
             /// Room accessed via Element Web/Desktop's Unified Search modal.
             case WebUnifiedSearch
             /// Room accessed via the Element Web/Desktop vertical breadcrumb hover menu.


### PR DESCRIPTION
We are adding analytics for the new [Threads Activity Centre](https://github.com/element-hq/wat-internal/issues/93) (https://github.com/element-hq/wat-internal/issues/133).

Two interactions:
- One is when the Threads Activity Centre button on the left panel of EW is clicked
- The other is when a room inside the Threads Activity Centre is clicked

We are also a new trigger from the TAC for the `ViewRoom` event.
