### PR TITLE
Add a new platform code super property

### DIFF
--- a/kotlin/lib/src/main/java/im/vector/app/features/analytics/plan/SuperProperties.kt
+++ b/kotlin/lib/src/main/java/im/vector/app/features/analytics/plan/SuperProperties.kt
@@ -38,6 +38,10 @@ data class SuperProperties(
          * Version of the crypto backend.
          */
         val cryptoSDKVersion: String? = null,
+        /**
+         * Used as a discriminant to breakdown usage per client.
+         */
+        val platformCodeName: PlatformCodeName? = null,
 ) {
 
     enum class CryptoSDK {
@@ -52,11 +56,50 @@ data class SuperProperties(
         Rust,
     }
 
+    enum class PlatformCodeName {
+
+        /**
+         * Element Desktop platform code.
+         */
+        Desktop,
+
+        /**
+         * Element Android platform code.
+         */
+        EA,
+
+        /**
+         * Element iOS platform code.
+         */
+        EI,
+
+        /**
+         * Element-X Android platform code.
+         */
+        EXA,
+
+        /**
+         * Element-X iOS platform code.
+         */
+        EXI,
+
+        /**
+         * Other Platform code.
+         */
+        Other,
+
+        /**
+         * Element Web platform code.
+         */
+        Web,
+    }
+
     fun getProperties(): Map<String, Any>? {
         return mutableMapOf<String, Any>().apply {
             appPlatform?.let { put("appPlatform", it) }
             cryptoSDK?.let { put("cryptoSDK", it.name) }
             cryptoSDKVersion?.let { put("cryptoSDKVersion", it) }
+            platformCodeName?.let { put("platformCodeName", it.name) }
         }.takeIf { it.isNotEmpty() }
     }
 }

--- a/schemas/SuperProperties.json
+++ b/schemas/SuperProperties.json
@@ -17,6 +17,20 @@
     "appPlatform": {
       "description": "Used by web to identify the platform (Web Platform/Electron Platform).",
       "type": "string"
+    },
+
+    "platformCodeName": {
+      "description": "Used as a discriminant to breakdown usage per client.",
+      "type": "string",
+      "oneOf": [
+        {"const": "Web", "description": "Element Web platform code."},
+        {"const": "Desktop", "description": "Element Desktop platform code."},
+        {"const": "EI", "description": "Element iOS platform code."},
+        {"const": "EXI", "description": "Element-X iOS platform code."},
+        {"const": "EA", "description": "Element Android platform code."},
+        {"const": "EXA", "description": "Element-X Android platform code."},
+        {"const": "Other", "description": "Other Platform code."}
+      ]
     }
   },
   "required": [],

--- a/types/swift/SuperProperties.swift
+++ b/types/swift/SuperProperties.swift
@@ -29,11 +29,14 @@ extension AnalyticsEvent {
         public let cryptoSDK: CryptoSDK?
         /// Version of the crypto backend.
         public let cryptoSDKVersion: String?
+        /// Used as a discriminant to breakdown usage per client.
+        public let platformCodeName: PlatformCodeName?
 
-        public init(appPlatform: String?, cryptoSDK: CryptoSDK?, cryptoSDKVersion: String?) {
+        public init(appPlatform: String?, cryptoSDK: CryptoSDK?, cryptoSDKVersion: String?, platformCodeName: PlatformCodeName?) {
             self.appPlatform = appPlatform
             self.cryptoSDK = cryptoSDK
             self.cryptoSDKVersion = cryptoSDKVersion
+            self.platformCodeName = platformCodeName
         }
 
         public enum CryptoSDK: String {
@@ -43,11 +46,29 @@ extension AnalyticsEvent {
             case Rust
         }
 
+        public enum PlatformCodeName: String {
+            /// Element Desktop platform code.
+            case Desktop
+            /// Element Android platform code.
+            case EA
+            /// Element iOS platform code.
+            case EI
+            /// Element-X Android platform code.
+            case EXA
+            /// Element-X iOS platform code.
+            case EXI
+            /// Other Platform code.
+            case Other
+            /// Element Web platform code.
+            case Web
+        }
+
         public var properties: [String: Any?] {
             return [
                 "appPlatform": appPlatform,
                 "cryptoSDK": cryptoSDK?.rawValue,
-                "cryptoSDKVersion": cryptoSDKVersion
+                "cryptoSDKVersion": cryptoSDKVersion,
+                "platformCodeName": platformCodeName?.rawValue
             ]
         }
     }


### PR DESCRIPTION
Fixes https://github.com/element-hq/crypto-internal/issues/316

Unfortunately I cannot just use the existing app platform, because it uses values with white space ([Web Platform](https://github.com/element-hq/element-web/blob/153d0c36b88df41b0063284181853ccb92a5a310/src/vector/platform/WebPlatform.ts#L86)). The script we use to generate swift/kotlin enum will generate invalid code for such values.
We are using some custom python script to convert, not sure if worth finding how to fix them
