### PR TITLE
Remove `platformCodeName` super property, and use existing `appPlatform` instead

### DIFF
--- a/kotlin/lib/src/main/java/im/vector/app/features/analytics/plan/SuperProperties.kt
+++ b/kotlin/lib/src/main/java/im/vector/app/features/analytics/plan/SuperProperties.kt
@@ -26,10 +26,9 @@ package im.vector.app.features.analytics.plan
  */
 data class SuperProperties(
         /**
-         * Used by web to identify the platform (Web Platform/Electron
-         * Platform).
+         * Used as a discriminant to breakdown usage per client.
          */
-        val appPlatform: String? = null,
+        val appPlatform: AppPlatform? = null,
         /**
          * Which crypto backend is the client currently using.
          */
@@ -38,10 +37,6 @@ data class SuperProperties(
          * Version of the crypto backend.
          */
         val cryptoSDKVersion: String? = null,
-        /**
-         * Used as a discriminant to breakdown usage per client.
-         */
-        val platformCodeName: PlatformCodeName? = null,
 ) {
 
     enum class CryptoSDK(val rawValue: String) {
@@ -56,50 +51,49 @@ data class SuperProperties(
         Rust("Rust"),
     }
 
-    enum class PlatformCodeName(val rawValue: String) {
+    enum class AppPlatform(val rawValue: String) {
 
         /**
-         * Element Desktop platform code.
-         */
-        Desktop("Desktop"),
-
-        /**
-         * Element Android platform code.
+         * Element Android platform.
          */
         EA("EA"),
 
         /**
-         * Element iOS platform code.
+         * Element iOS platform.
          */
         EI("EI"),
 
         /**
-         * Element-X Android platform code.
+         * Element-X Android platform.
          */
         EXA("EXA"),
 
         /**
-         * Element-X iOS platform code.
+         * Element-X iOS platform.
          */
         EXI("EXI"),
 
         /**
-         * Other Platform code.
+         * Element Desktop platform.
+         */
+        ElectronPlatform("Electron Platform"),
+
+        /**
+         * Other Platform.
          */
         Other("Other"),
 
         /**
-         * Element Web platform code.
+         * Element Web platform.
          */
-        Web("Web"),
+        WebPlatform("Web Platform"),
     }
 
     fun getProperties(): Map<String, Any>? {
         return mutableMapOf<String, Any>().apply {
-            appPlatform?.let { put("appPlatform", it) }
+            appPlatform?.let { put("appPlatform", it.rawValue) }
             cryptoSDK?.let { put("cryptoSDK", it.rawValue) }
             cryptoSDKVersion?.let { put("cryptoSDKVersion", it) }
-            platformCodeName?.let { put("platformCodeName", it.rawValue) }
         }.takeIf { it.isNotEmpty() }
     }
 }

--- a/schemas/SuperProperties.json
+++ b/schemas/SuperProperties.json
@@ -15,21 +15,16 @@
       "type": "string"
     },
     "appPlatform": {
-      "description": "Used by web to identify the platform (Web Platform/Electron Platform).",
-      "type": "string"
-    },
-
-    "platformCodeName": {
       "description": "Used as a discriminant to breakdown usage per client.",
       "type": "string",
       "oneOf": [
-        {"const": "Web", "description": "Element Web platform code."},
-        {"const": "Desktop", "description": "Element Desktop platform code."},
-        {"const": "EI", "description": "Element iOS platform code."},
-        {"const": "EXI", "description": "Element-X iOS platform code."},
-        {"const": "EA", "description": "Element Android platform code."},
-        {"const": "EXA", "description": "Element-X Android platform code."},
-        {"const": "Other", "description": "Other Platform code."}
+        {"const": "Web Platform", "description": "Element Web platform."},
+        {"const": "Electron Platform", "description": "Element Desktop platform."},
+        {"const": "EI", "description": "Element iOS platform."},
+        {"const": "EXI", "description": "Element-X iOS platform."},
+        {"const": "EA", "description": "Element Android platform."},
+        {"const": "EXA", "description": "Element-X Android platform."},
+        {"const": "Other", "description": "Other Platform."}
       ]
     }
   },

--- a/types/swift/SuperProperties.swift
+++ b/types/swift/SuperProperties.swift
@@ -23,20 +23,17 @@ import Foundation
 extension AnalyticsEvent {
     public struct SuperProperties {
 
-        /// Used by web to identify the platform (Web Platform/Electron Platform).
-        public let appPlatform: String?
+        /// Used as a discriminant to breakdown usage per client.
+        public let appPlatform: AppPlatform?
         /// Which crypto backend is the client currently using.
         public let cryptoSDK: CryptoSDK?
         /// Version of the crypto backend.
         public let cryptoSDKVersion: String?
-        /// Used as a discriminant to breakdown usage per client.
-        public let platformCodeName: PlatformCodeName?
 
-        public init(appPlatform: String?, cryptoSDK: CryptoSDK?, cryptoSDKVersion: String?, platformCodeName: PlatformCodeName?) {
+        public init(appPlatform: AppPlatform?, cryptoSDK: CryptoSDK?, cryptoSDKVersion: String?) {
             self.appPlatform = appPlatform
             self.cryptoSDK = cryptoSDK
             self.cryptoSDKVersion = cryptoSDKVersion
-            self.platformCodeName = platformCodeName
         }
 
         public enum CryptoSDK: String {
@@ -46,29 +43,28 @@ extension AnalyticsEvent {
             case Rust = "Rust"
         }
 
-        public enum PlatformCodeName: String {
-            /// Element Desktop platform code.
-            case Desktop = "Desktop"
-            /// Element Android platform code.
+        public enum AppPlatform: String {
+            /// Element Android platform.
             case EA = "EA"
-            /// Element iOS platform code.
+            /// Element iOS platform.
             case EI = "EI"
-            /// Element-X Android platform code.
+            /// Element-X Android platform.
             case EXA = "EXA"
-            /// Element-X iOS platform code.
+            /// Element-X iOS platform.
             case EXI = "EXI"
-            /// Other Platform code.
+            /// Element Desktop platform.
+            case ElectronPlatform = "Electron Platform"
+            /// Other Platform.
             case Other = "Other"
-            /// Element Web platform code.
-            case Web = "Web"
+            /// Element Web platform.
+            case WebPlatform = "Web Platform"
         }
 
         public var properties: [String: Any?] {
             return [
-                "appPlatform": appPlatform,
+                "appPlatform": appPlatform?.rawValue,
                 "cryptoSDK": cryptoSDK?.rawValue,
-                "cryptoSDKVersion": cryptoSDKVersion,
-                "platformCodeName": platformCodeName?.rawValue
+                "cryptoSDKVersion": cryptoSDKVersion
             ]
         }
     }


### PR DESCRIPTION
Depends on https://github.com/matrix-org/matrix-analytics-events/pull/105 as the existing Values for appPlatform have white spaces

Remove`platformCodeName` and reuse `appPlatform` has now we can have enum values with whitespace.
Reverts https://github.com/matrix-org/matrix-analytics-events/pull/104 and adding the new needed enum values as per https://github.com/element-hq/crypto-internal/issues/316

First [commit](https://github.com/matrix-org/matrix-analytics-events/pull/106/commits/d04a3832fadad268deb4682f3f0ccdbb12ef00d0) has the schema changes. The other one is just running the script to generate the updated swift/kotlin files