### PR TITLE
Update error code for withheld keys

### DIFF
--- a/kotlin/lib/src/main/java/im/vector/app/features/analytics/plan/Error.kt
+++ b/kotlin/lib/src/main/java/im/vector/app/features/analytics/plan/Error.kt
@@ -109,9 +109,10 @@ data class Error(
         OlmUnspecifiedError("OlmUnspecifiedError"),
 
         /**
-         * E2EE domain error. The sender withheld the keys for this message.
+         * E2EE domain error. The sender withheld the keys for this message, due
+         * to the recipient device being unverified.
          */
-        RoomKeysWithheld("RoomKeysWithheld"),
+        RoomKeysWithheldForUnverifiedDevice("RoomKeysWithheldForUnverifiedDevice"),
 
         /**
          * TO_DEVICE domain error. The to-device message failed to decrypt.

--- a/schemas/Error.json
+++ b/schemas/Error.json
@@ -22,7 +22,7 @@
         {"const": "UnknownError", "description": "E2EE domain error. Decryption failed due to unknown error."},
         {"const": "HistoricalMessage", "description": "E2EE domain error. Decryption failed for a message sent before the device logged in, and key backup is not enabled."},
         {"const": "ExpectedDueToMembership", "description": "E2EE domain error. Decryption failed for a message sent before you were in the room (shared history visibility and support for sharing past keys is not available/supported)."},
-        {"const": "RoomKeysWithheld", "description": "E2EE domain error. The sender withheld the keys for this message."},
+        {"const": "RoomKeysWithheldForUnverifiedDevice", "description": "E2EE domain error. The sender withheld the keys for this message, due to the recipient device being unverified."},
         {"const": "VoipUserHangup", "description": "VOIP domain error. The user hung up the call."},
         {"const": "VoipIceFailed", "description": "VOIP domain error. ICE negotiation failed."},
         {"const": "VoipInviteTimeout", "description": "VOIP domain error. The call invite timed out."},

--- a/types/swift/Error.swift
+++ b/types/swift/Error.swift
@@ -76,8 +76,8 @@ extension AnalyticsEvent {
             case OlmKeysNotSentError = "OlmKeysNotSentError"
             /// E2EE domain error. Any other decryption error (missing field, format errors...).
             case OlmUnspecifiedError = "OlmUnspecifiedError"
-            /// E2EE domain error. The sender withheld the keys for this message.
-            case RoomKeysWithheld = "RoomKeysWithheld"
+            /// E2EE domain error. The sender withheld the keys for this message, due to the recipient device being unverified.
+            case RoomKeysWithheldForUnverifiedDevice = "RoomKeysWithheldForUnverifiedDevice"
             /// TO_DEVICE domain error. The to-device message failed to decrypt.
             case ToDeviceFailedToDecrypt = "ToDeviceFailedToDecrypt"
             /// E2EE domain error. Decryption failed due to unknown error.


### PR DESCRIPTION
We only actually want a separate error when the error is "m.unverified"

Part of https://github.com/element-hq/element-web/issues/27653