### PR TITLE
Feat: New expected UTD mode due to decryption TrustRequirement

### DIFF
--- a/kotlin/lib/src/main/java/im/vector/app/features/analytics/plan/Error.kt
+++ b/kotlin/lib/src/main/java/im/vector/app/features/analytics/plan/Error.kt
@@ -86,6 +86,18 @@ data class Error(
         ExpectedDueToMembership("ExpectedDueToMembership"),
 
         /**
+         * E2EE domain error. Decryption failed for a message because it was
+         * sent by an insecure device
+         */
+        ExpectedSentByInsecureDevice("ExpectedSentByInsecureDevice"),
+
+        /**
+         * E2EE domain error. Decryption failed for a message because the
+         * sender's verified identity has changed.
+         */
+        ExpectedVerificationViolation("ExpectedVerificationViolation"),
+
+        /**
          * E2EE domain error. Decryption failed for a message sent before the
          * device logged in, and key backup is not enabled.
          */

--- a/schemas/Error.json
+++ b/schemas/Error.json
@@ -22,6 +22,8 @@
         {"const": "UnknownError", "description": "E2EE domain error. Decryption failed due to unknown error."},
         {"const": "HistoricalMessage", "description": "E2EE domain error. Decryption failed for a message sent before the device logged in, and key backup is not enabled."},
         {"const": "ExpectedDueToMembership", "description": "E2EE domain error. Decryption failed for a message sent before you were in the room (shared history visibility and support for sharing past keys is not available/supported)."},
+        {"const": "ExpectedSentByInsecureDevice", "description": "E2EE domain error. Decryption failed for a message because it was sent by an insecure device"},
+        {"const": "ExpectedVerificationViolation", "description": "E2EE domain error. Decryption failed for a message because the sender's verified identity has changed."},
         {"const": "RoomKeysWithheldForUnverifiedDevice", "description": "E2EE domain error. The sender withheld the keys for this message, due to the recipient device being unverified."},
         {"const": "VoipUserHangup", "description": "VOIP domain error. The user hung up the call."},
         {"const": "VoipIceFailed", "description": "VOIP domain error. ICE negotiation failed."},

--- a/types/swift/Error.swift
+++ b/types/swift/Error.swift
@@ -68,6 +68,10 @@ extension AnalyticsEvent {
         public enum Name: String {
             /// E2EE domain error. Decryption failed for a message sent before you were in the room (shared history visibility and support for sharing past keys is not available/supported).
             case ExpectedDueToMembership = "ExpectedDueToMembership"
+            /// E2EE domain error. Decryption failed for a message because it was sent by an insecure device
+            case ExpectedSentByInsecureDevice = "ExpectedSentByInsecureDevice"
+            /// E2EE domain error. Decryption failed for a message because the sender's verified identity has changed.
+            case ExpectedVerificationViolation = "ExpectedVerificationViolation"
             /// E2EE domain error. Decryption failed for a message sent before the device logged in, and key backup is not enabled.
             case HistoricalMessage = "HistoricalMessage"
             /// E2EE domain error. The room key is known but is ratcheted (index > 0).


### PR DESCRIPTION
Adding new expected UTD code following the new UTD cause due to TrustRequirements (see https://github.com/matrix-org/matrix-rust-sdk/pull/4126)