### PR TITLE
Update runners to ubuntu-latest

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   gradle:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     concurrency:
       # When running on main, use the sha to allow all runs of this workflow to run concurrently.

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-15
+    runs-on: macos-14
 
     concurrency:
       # When running on main, use the sha to allow all runs of this workflow to run concurrently.

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,9 +19,9 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install Swift
-      uses: slashmo/install-swift@v0.4.0
+      uses: swift-actions/setup-swift@v2
       with:
-        version: 5.7
+        swift-version: "5.7.0"
 
     - name: Build for Swift
       run: swift build

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install Swift
       uses: swift-actions/setup-swift@v2
       with:
-        swift-version: "5.7.0"
+        swift-version: "5.7"
 
     - name: Build for Swift
       run: swift build

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     concurrency:
       # When running on main, use the sha to allow all runs of this workflow to run concurrently.

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -18,14 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: '15.0.1'
-
     - name: Install Swift
       uses: swift-actions/setup-swift@v2
       with:
-        swift-version: "5.7"
+        swift-version: "6.1"
 
     - name: Build for Swift
       run: swift build

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install Swift
-      uses: slashmo/install-swift@v0.3.0
+      uses: slashmo/install-swift@v0.4.0
       with:
         version: 5.7
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-15
 
     concurrency:
       # When running on main, use the sha to allow all runs of this workflow to run concurrently.
@@ -21,7 +21,7 @@ jobs:
     - name: Install Swift
       uses: swift-actions/setup-swift@v2
       with:
-        swift-version: "5.7.3"
+        swift-version: "5.7"
 
     - name: Build for Swift
       run: swift build

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -18,6 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '15.4'
+
     - name: Install Swift
       uses: swift-actions/setup-swift@v2
       with:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -20,7 +20,7 @@ jobs:
 
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '15.4'
+        xcode-version: '14.3.1'
 
     - name: Install Swift
       uses: swift-actions/setup-swift@v2

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -20,7 +20,7 @@ jobs:
 
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '14.3.1'
+        xcode-version: '15.0.1'
 
     - name: Install Swift
       uses: swift-actions/setup-swift@v2

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install Swift
       uses: swift-actions/setup-swift@v2
       with:
-        swift-version: "5.7"
+        swift-version: "5.7.9"
 
     - name: Build for Swift
       run: swift build

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install Swift
       uses: swift-actions/setup-swift@v2
       with:
-        swift-version: "5.7.9"
+        swift-version: "5.7.3"
 
     - name: Build for Swift
       run: swift build

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 6.1
 
 import PackageDescription
 


### PR DESCRIPTION
- ubuntu-latest seems fine for Kotlin
- For swift I've updated the swift action to swift-setup which seems like a more rent maintained one. When https://github.com/swift-actions/setup-swift/pull/772 is fixed we can probably move back to an ubuntu runner. To get it working I've used macos runner and updated the toolchain.