### PR TITLE
Mark eventName as required on UrlPreview* events.

### DIFF
--- a/schemas/UrlPreviewRendered.json
+++ b/schemas/UrlPreviewRendered.json
@@ -23,6 +23,12 @@
       "type": "boolean"
     }
   },
-  "required": ["previewKind", "encryptedRoom", "previewCount", "hasThumbnail"],
+  "required": [
+    "eventName",
+    "previewKind",
+    "encryptedRoom",
+    "previewCount",
+    "hasThumbnail"
+  ],
   "additionalProperties": false
 }

--- a/schemas/UrlPreviewVisibilityChanged.json
+++ b/schemas/UrlPreviewVisibilityChanged.json
@@ -23,6 +23,12 @@
       "type": "boolean"
     }
   },
-  "required": ["visible", "previewKind", "previewCount", "hasThumbnail"],
+  "required": [
+    "eventName",
+    "visible",
+    "previewKind",
+    "previewCount",
+    "hasThumbnail"
+  ],
   "additionalProperties": false
 }


### PR DESCRIPTION
Third times the charm, fixes #130 and #129 