### PR TITLE
Fix release actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,5 +83,5 @@ jobs:
               body: `${version} Release`,
               draft: false,
               prerelease: false,
-              make_latest: true,
+              make_latest: "true",
             });


### PR DESCRIPTION
CI is failing https://github.com/matrix-org/matrix-analytics-events/actions/runs/26390360914
```
Run actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
RequestError [HttpError]: Invalid request.

For 'properties/make_latest', true is not a string.
    at /home/runner/work/_actions/actions/github-script/ed597411d8f924073f98dfc5c65a23a2325f34cd/dist/index.js:9537:21
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async requestWithGraphqlErrorHandling (/home/runner/work/_actions/actions/github-script/ed597411d8f924073f98dfc5c65a23a2325f34cd/dist/index.js:9276:20)
    at async Job.doExecute (/home/runner/work/_actions/actions/github-script/ed597411d8f924073f98dfc5c65a23a2325f34cd/dist/index.js:10275:18) {
  status: 422,
  response: {
    url: 'https://api.github.com/repos/matrix-org/matrix-analytics-events/releases',
    status: 422,
    headers: {
      'access-control-allow-origin': '*',
      'access-control-expose-headers': 'ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset, Warning',
      'content-length': '186',
      'content-security-policy': "default-src 'none'",
      'content-type': 'application/json; charset=utf-8',
      date: 'Mon, 25 May 2026 08:07:40 GMT',
      'referrer-policy': 'origin-when-cross-origin, strict-origin-when-cross-origin',
      server: 'github.com',
      'strict-transport-security': 'max-age=31536000; includeSubdomains; preload',
      vary: 'Accept-Encoding, Accept, X-Requested-With',
      'x-accepted-github-permissions': 'contents=write; contents=write,workflows=write',
      'x-content-type-options': 'nosniff',
      'x-frame-options': 'deny',
      'x-github-api-version-selected': '2022-11-28',
      'x-github-media-type': 'github.v3; format=json',
      'x-github-request-id': '6C40:350855:4ED3C90:129D2D6A:6A14034C',
      'x-ratelimit-limit': '5000',
      'x-ratelimit-remaining': '4981',
      'x-ratelimit-reset': '1779700052',
      'x-ratelimit-resource': 'core',
      'x-ratelimit-used': '19',
      'x-xss-protection': '0'
    },
    data: {
      message: "Invalid request.\n\nFor 'properties/make_latest', true is not a string.",
      documentation_url: 'https://docs.github.com/rest/releases/releases#create-a-release',
      status: '422'
    }
  },
  request: {
    method: 'POST',
    url: 'https://api.github.com/repos/matrix-org/matrix-analytics-events/releases',
    headers: {
      accept: 'application/vnd.github.v3+json',
      'user-agent': 'actions/github-script octokit-core.js/5.0.1 Node.js/24',
      authorization: 'token [REDACTED]',
      'content-type': 'application/json; charset=utf-8'
    },
    body: '{"tag_name":"v0.35.0","name":"Release 0.35.0","body":"0.35.0 Release","draft":false,"prerelease":false,"make_latest":true}',
    request: {
      agent: [Agent],
      fetch: [Function: proxyFetch],
      retries: 3,
      hook: [Function: bound bound register],
      retryCount: 3
    }
  }
}
Error: Unhandled error: HttpError: Invalid request.

For 'properties/make_latest', true is not a string.
```
`make_latest` should be a string https://docs.github.com/en/rest/releases/releases?apiVersion=2026-03-10#create-a-release 